### PR TITLE
Change max width on textinput

### DIFF
--- a/src/reactapp/src/components/common/Form/TextInput/TextInput.jsx
+++ b/src/reactapp/src/components/common/Form/TextInput/TextInput.jsx
@@ -64,7 +64,7 @@ function TextInput({
           setFieldTouched(name, newValue);
           setFieldValue(name, newValue);
         }}
-        className={`form-input max-w-md ${
+        className={`form-input max-w-3xl ${
           hasError ? 'border-dashed border-red-500' : ''
         } ${className} ${width || 'w-full'}`}
         {...rest}


### PR DESCRIPTION
This is so the fields on the address fill the whole width of the screen and don't leave blank space. This change is really for aesthetics.