### PR TITLE
Fix display format of address

### DIFF
--- a/src/reactapp/src/utils/address.js
+++ b/src/reactapp/src/utils/address.js
@@ -47,10 +47,11 @@ export function formatAddressListToCardData(addressList, stateList) {
         fullName,
         company,
         ...street,
+        __('%1 %1', zipcode, city),
         city,
         regionLabel || _get(countryRegion, 'name'),
-        __('%1 zipcode: %1', countryCode || country, zipcode),
-        __('phone: %1', phone),
+        countryCode || country
+        __('Phone: %1', phone),
       ].filter((i) => !!i),
     };
   });


### PR DESCRIPTION
Changed display format of the address and capitalized 'Phone'.

Before: 

![image](https://user-images.githubusercontent.com/431360/136140859-615a8183-d276-43e0-a90b-1307f9c79506.png)

After:

![image](https://user-images.githubusercontent.com/431360/136140985-a528a74d-8e41-46f6-a2f0-90c7f58e6c0f.png)