### PR TITLE
Add defaultValue parameter for Textinput

### DIFF
--- a/src/reactapp/src/components/common/Form/TextInput.jsx
+++ b/src/reactapp/src/components/common/Form/TextInput.jsx
@@ -18,6 +18,7 @@ function TextInput({
   className,
   formikData,
   placeholder,
+  defaultValue,
   ...rest
 }) {
   const {
@@ -31,7 +32,7 @@ function TextInput({
   const inputId = id || name;
   const relativeFieldName = _replace(name, formSectionId).replace('.', '');
   const hasFieldError = !!_get(formSectionErrors, relativeFieldName);
-  const value = _get(formSectionValues, relativeFieldName, '') || '';
+  const value = _get(formSectionValues, relativeFieldName, defaultValue) || '';
   const hasFieldTouched = !!_get(formSectionTouched, relativeFieldName);
   const hasError = hasFieldError && hasFieldTouched;
 
@@ -85,6 +86,7 @@ TextInput.propTypes = {
   helpText: string,
   className: string,
   placeholder: string,
+  defaultValue: string,
   name: string.isRequired,
   formikData: formikDataShape.isRequired,
 };
@@ -98,6 +100,7 @@ TextInput.defaultProps = {
   className: '',
   required: false,
   placeholder: '',
+  defaultValue: '',
   isHidden: false,
 };
 


### PR DESCRIPTION
Certain payment methods i am currently implementing need extra information from the user. Sometimes this information is already available in the billing address, so i want to put a default value in the Textinput based on certain information in the billing address so the user only has to check if it is correct and change it if he wants.

Currently this is not possible with the Textinput component, because the defaultValue is hardcoded as an empty string. Let me know if this change is correct/wanted. If not i can always create my own Textinput component, but i thought this might be useful to others as well.