### PR TITLE
fix for swapping setting billing and shipping

### DIFF
--- a/src/reactapp/src/components/shippingAddress/hooks/useFillDefaultAddresses.js
+++ b/src/reactapp/src/components/shippingAddress/hooks/useFillDefaultAddresses.js
@@ -83,8 +83,8 @@ export default function useFillDefaultAddresses(shippingContext) {
 
     try {
       setPageLoader(true);
-      await saveBillingPromise();
       await saveShippingPromise();
+      await saveBillingPromise();
 
       if (isBillingGoingToSave) {
         const formAddressToFill = prepareFormAddressFromCartAddress(


### PR DESCRIPTION
I found a problem when you open checkout and login to M2 from the checkout itself

You get the error which is something like... can't set billing address same as shipping address when shipping address has not been set. The problem is that the billing address is not set and hence you can't checkout.

I found the place where this is set and swapped the order.. so the shipping is set first and then billing and now all seems ok. I don't think there are any other occurrences of this.
~jono