### PR TITLE
The current sendRequest does not handle returned errors if data is present

### DIFF
--- a/src/reactapp/src/api/sendRequest.js
+++ b/src/reactapp/src/api/sendRequest.js
@@ -50,17 +50,17 @@ export default function sendRequest(
       return response.json();
     })
     .then((response) => {
-      if (!responseContainErrors(response) || !responseDataEmpty(response)) {
-        return response;
+      if (responseContainErrors(response)) {
+        const exception = new GraphQLResponseException(response);
+        dispatch({
+          type: SET_PAGE_MESSAGE,
+          payload: { type: 'error', message: exception.message },
+        });
+        if (responseDataEmpty(response)) {
+          throw exception;
+        }
       }
-
-      const exception = new GraphQLResponseException(response);
-
-      dispatch({
-        type: SET_PAGE_MESSAGE,
-        payload: { type: 'error', message: exception.message },
-      });
-      throw exception;
+      return response;
     })
     .catch((exception) => {
       console.error(exception);


### PR DESCRIPTION
The aggregateQuery can return data and errors. The case I found was where a logged in user does a mergeCart and the requested quantity is no longer available. So the returned cart has a data object and an error object. 

The user needs to see this error otherwise the cart goes blank and there is no explanation as to what happened. 

The other issue is that the cart is not parsed correctly, but I will leave this for the moment. Its more important that the error is displayed.

![data and errors](https://user-images.githubusercontent.com/1988002/171796698-a8012e34-3a97-462b-bf26-6be4f27cf3d1.jpg)
