### PR TITLE
Minor improvements

### DIFF
--- a/src/reactapp/src/components/common/Form/RadioInput.jsx
+++ b/src/reactapp/src/components/common/Form/RadioInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Field } from 'formik';
-import { bool, string } from 'prop-types';
+import { bool, node, string } from 'prop-types';
 
 function RadioInput({
   id,
@@ -16,19 +16,23 @@ function RadioInput({
 
   return (
     <div className="mt-2 form-control">
-      <Field
-        name={name}
-        type="radio"
-        id={inputId}
-        checked={checked}
-        className="form-radio"
-        {...rest}
-      />
-      {label && (
-        <label htmlFor={inputId} className="inline-block pl-2">
-          {label}
-        </label>
-      )}
+      <div className="flex items-center">
+        <Field
+          name={name}
+          type="radio"
+          id={inputId}
+          checked={checked}
+          className="form-radio"
+          {...rest}
+        />
+        {label && !React.isValidElement(label) ? (
+          <label htmlFor={inputId} className="inline-block pl-2 cursor-pointer">
+            {label}
+          </label>
+        ) : (
+          label
+        )}
+      </div>
 
       <div className="text-xs" id={`${inputId}-help`} tabIndex="-1">
         {helpText}
@@ -39,11 +43,11 @@ function RadioInput({
 
 RadioInput.propTypes = {
   id: string,
-  label: string,
+  label: node,
   checked: bool,
   required: bool,
-  helpText: string,
-  placeholder: string,
+  helpText: node,
+  placeholder: node,
   name: string.isRequired,
 };
 

--- a/src/reactapp/src/components/paymentMethod/context/PaymentMethodFormContext.js
+++ b/src/reactapp/src/components/paymentMethod/context/PaymentMethodFormContext.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
-const PaymentMethodFormContext = React.createContext();
+import { PaymentMethodFormContext } from '../../../context/Form';
 
 export default PaymentMethodFormContext;

--- a/src/reactapp/src/components/shippingMethod/context/ShippingMethodFormContext.js
+++ b/src/reactapp/src/components/shippingMethod/context/ShippingMethodFormContext.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
-const ShippingMethodFormContext = React.createContext();
+import { ShippingMethodFormContext } from '../../../context/Form';
 
 export default ShippingMethodFormContext;

--- a/src/reactapp/src/context/Form/PaymentMethodFormContext.js
+++ b/src/reactapp/src/context/Form/PaymentMethodFormContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const PaymentMethodFormContext = React.createContext();
+
+export default PaymentMethodFormContext;

--- a/src/reactapp/src/context/Form/ShippingMethodFormContext.js
+++ b/src/reactapp/src/context/Form/ShippingMethodFormContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ShippingMethodFormContext = React.createContext();
+
+export default ShippingMethodFormContext;

--- a/src/reactapp/src/context/Form/index.js
+++ b/src/reactapp/src/context/Form/index.js
@@ -1,7 +1,3 @@
-import FormStepProvider from './Step/StepProvider';
-
-import FormStepCxt from './Step/StepContext';
-
-export const StepProvider = FormStepProvider;
-
-export const StepContext = FormStepCxt;
+export { default as CheckoutFormContext } from './CheckoutFormContext';
+export { default as PaymentMethodFormContext } from './PaymentMethodFormContext';
+export { default as ShippingMethodFormContext } from './ShippingMethodFormContext';

--- a/src/view/frontend/templates/react-container.phtml
+++ b/src/view/frontend/templates/react-container.phtml
@@ -15,7 +15,7 @@ $configProvider = $block->getData('checkout_config_provider');
     id="react-checkout"
     data-base_url="<?= $block->getBaseUrl() ?>"
     data-checkout_config="<?= $escaper->escapeHtmlAttr($configProvider->getConfig()) ?>"
-    data-static_file_path="<?= $escaper->escapeUrl($block->getViewFileUrl('Hyva_ReactCheckout')) ?>"
+    data-static_file_path="<?= $escaper->escapeUrl($block->getViewFileUrl('')) ?>"
 >
     <div class="container">
         <div class="flex flex-col max-h-screen my-6 lg:flex-row">


### PR DESCRIPTION
- Make label, helperText of RadioInput component of type node (instead of string) so that it allows to pass html also.
- Move payment/shipping form context to the src/context directory so that it can be referred by payment/shipping integrations without worrying about the versions of the checkout being used
- Pass static path reference without the Hyva_ReactCheckout reference. This will allow us to refer other modules if we want to access their assets.