### PR TITLE
Feature: Add hyva_react_checkout_config event to be able to alter the checkout config

### DIFF
--- a/src/ViewModel/CheckoutConfigProvider.php
+++ b/src/ViewModel/CheckoutConfigProvider.php
@@ -79,15 +79,18 @@ class CheckoutConfigProvider implements ArgumentInterface
         $checkoutConfig['payment']['restUrlPrefix'] = "/rest/$storeCode/V1/";
 
         $transport = new \Magento\Framework\DataObject([
-          'storeCode' => $storeCode,
-          'payment' => $checkoutConfig['payment'],
-          'language' => $this->localeResolver->getLocale(),
-          'currency' => $this->currencyProvider->getConfig(),
-          'defaultCountryId' => $checkoutConfig['defaultCountryId'],
+            'checkoutConfig' => $checkoutConfig,
+            'output' => [
+                'storeCode' => $storeCode,
+                'payment' => $checkoutConfig['payment'],
+                'language' => $this->localeResolver->getLocale(),
+                'currency' => $this->currencyProvider->getConfig(),
+                'defaultCountryId' => $checkoutConfig['defaultCountryId'],
+            ]
         ]);
 
         $this->eventManager->dispatch('hyva_react_checkout_config', ['transport' => $transport]);
 
-        return $this->serializer->serialize($transport->getData());
+        return $this->serializer->serialize($transport->getData('output'));
     }
 }


### PR DESCRIPTION
Recently in version 1.1.2 the ability to support shipping methods was added, which is great. For some shipping methods implementations, we need access to configuration items. In the regular Magento checkout, any module can dump any setting into the `window.checkoutConfig` configuration. The current React checkout only passes the `payment` configuration. 

In this PR, I've added an event that allows developers to extend the checkoutConfig however needed. 