### PR TITLE
#278 Return currency code when symbol not available

### DIFF
--- a/src/ViewModel/CurrencyProvider.php
+++ b/src/ViewModel/CurrencyProvider.php
@@ -75,6 +75,6 @@ class CurrencyProvider implements ArgumentInterface
     {
         // do not use $this->storeManager->getStore()->getCurrentCurrencyCode() because of probability
         // to get an invalid (without base rate) currency from code saved in session
-        return return $this->getCurrentCurrency()->getCurrencySymbol() ?: $this->getCurrentCurrencyCode();
+        return $this->getCurrentCurrency()->getCurrencySymbol() ?: $this->getCurrentCurrencyCode();
     }
 }

--- a/src/ViewModel/CurrencyProvider.php
+++ b/src/ViewModel/CurrencyProvider.php
@@ -75,6 +75,6 @@ class CurrencyProvider implements ArgumentInterface
     {
         // do not use $this->storeManager->getStore()->getCurrentCurrencyCode() because of probability
         // to get an invalid (without base rate) currency from code saved in session
-        return $this->getCurrentCurrency()->getCurrencySymbol();
+        return return $this->getCurrentCurrency()->getCurrencySymbol() ?: $this->getCurrentCurrencyCode();
     }
 }


### PR DESCRIPTION
Some currencies have a symbol that is equal to the currency code. Magento does not return a currencySymbol for these currencies, so we need to fallback to the currencyCode for those currencies.