### PR TITLE
#330 Initialize hyva-checkout-storage values

### DIFF
--- a/src/ViewModel/ReactCheckoutLocalStorage.php
+++ b/src/ViewModel/ReactCheckoutLocalStorage.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Hyva\ReactCheckout\ViewModel;
+
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Customer\Model\Address;
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class ReactCheckoutLocalStorage implements ArgumentInterface
+{
+    /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
+    /**
+     * @var CustomerSession
+     */
+    private $customerSession;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct(
+        CheckoutSession $checkoutSession,
+        CustomerSession $customerSession,
+        SerializerInterface $serializer
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->customerSession = $customerSession;
+        $this->serializer = $serializer;
+    }
+
+    public function getLocalStorageConfig(): string
+    {
+        $config = [
+            'customerIsLoggedIn' => $this->isCustomerLoggedIn(),
+            'quoteContainsBilling' => $this->hasQuoteContainsValidBillingAddress(),
+            'quoteContainsShipping' => $this->hasQuoteContainsValidShippingAddress(),
+            'defaultBillingAddressId' => $this->getCustomerDefaultBillingAddressId(),
+            'defaultShippingAddressId' => $this->getCustomerDefaultShippingAddressId(),
+            'quoteBillingAddressCustomerId' => $this->getQuoteBillingAddressCustomerId(),
+            'quoteShippingAddressCustomerId' => $this->getQuoteShippingAddressCustomerId(),
+        ];
+
+        return $this->serializer->serialize($config);
+    }
+
+    private function isCustomerLoggedIn(): bool
+    {
+        return $this->customerSession->isLoggedIn()
+            && $this->customerSession->getCustomer()->getCustomerId();
+    }
+
+    private function getCustomerDefaultBillingAddressId(): ?int
+    {
+        $defaultBillingAddress = $this->getCustomer()->getDefaultBillingAddress();
+
+        return $defaultBillingAddress instanceof Address
+            ? (int)$defaultBillingAddress->getId()
+            : null;
+    }
+
+    private function getCustomerDefaultShippingAddressId(): ?int
+    {
+        $defaultShippingAddress = $this->getCustomer()->getDefaultShippingAddress();
+
+        return $defaultShippingAddress instanceof Address
+            ? (int)$defaultShippingAddress->getId()
+            : null;
+    }
+
+    private function hasQuoteContainsValidBillingAddress(): bool
+    {
+        $errors = $this->checkoutSession->getQuote()->getBillingAddress()->validate();
+
+        return $errors === true;
+    }
+
+    private function hasQuoteContainsValidShippingAddress(): bool
+    {
+        $errors = $this->checkoutSession->getQuote()->getShippingAddress()->validate();
+
+        return $errors === true;
+    }
+
+    private function getQuoteBillingAddressCustomerId(): ?int
+    {
+        $customerAddressId = $this->checkoutSession->getQuote()->getBillingAddress()->getCustomerAddressId();
+
+        return $customerAddressId !== null
+            ? (int)$customerAddressId
+            : null;
+    }
+
+    private function getQuoteShippingAddressCustomerId(): ?int
+    {
+        $customerAddressId = $this->checkoutSession->getQuote()->getShippingAddress()->getCustomerAddressId();
+
+        return $customerAddressId !== null
+            ? (int)$customerAddressId
+            : null;
+    }
+
+    private function getCustomer(): Customer
+    {
+        return $this->customerSession->getCustomer();
+    }
+}

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Hyva_ReactCheckout" setup_version="1.0.0">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Hyva_ReactCheckout">
         <sequence>
             <module name="Magento_QuoteGraphQl"/>
             <module name="Magento_GraphQl"/>

--- a/src/view/frontend/layout/hyva_hyvareactcheckout_reactcheckout_index.xml
+++ b/src/view/frontend/layout/hyva_hyvareactcheckout_reactcheckout_index.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <remove src="Hyva_ReactCheckout::css/styles.css" />
+        <referenceBlock name="checkout.scripts" template="Hyva_ReactCheckout::react-script.phtml" />
+        <referenceBlock name="checkout.initiate.hyva-checkout-storage"
+                        template="Hyva_ReactCheckout::initiate-storage.phtml" />
     </head>
 </page>

--- a/src/view/frontend/layout/hyvareactcheckout_reactcheckout_index.xml
+++ b/src/view/frontend/layout/hyvareactcheckout_reactcheckout_index.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      layout="1column"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="Hyva_ReactCheckout::css/styles.css" defer="defer" />
     </head>
     <body>
         <referenceContainer name="content">
-
-            <block class="Hyva\ReactCheckout\Block\CheckoutTranslator" name="checkout.translations" template="Hyva_ReactCheckout::translation.phtml">
+            <block class="Hyva\ReactCheckout\Block\CheckoutTranslator"
+                   name="checkout.translations"
+                   template="Hyva_ReactCheckout::translation.phtml">
                 <arguments>
                     <argument name="checkout_translations" xsi:type="array">
                         <!--
@@ -34,7 +37,18 @@
             </block>
         </referenceContainer>
         <referenceContainer name="before.body.end">
-            <block name="checkout.scripts" template="Hyva_ReactCheckout::react-script.phtml" after="-"/>
+            <block name="checkout.initiate.hyva-checkout-storage"
+                   template="Hyva_ReactCheckout::luma/initiate-storage.phtml"
+                   after="-" >
+                <arguments>
+                    <argument
+                        name="hyva_react_checkout_localstorage"
+                        xsi:type="object">Hyva\ReactCheckout\ViewModel\ReactCheckoutLocalStorage</argument>
+                </arguments>
+            </block>
+            <block name="checkout.scripts"
+                   template="Hyva_ReactCheckout::luma/react-script.phtml"
+                   after="checkout.initiate.hyva-checkout-storage" />
         </referenceContainer>
     </body>
 </page>

--- a/src/view/frontend/templates/initiate-storage.phtml
+++ b/src/view/frontend/templates/initiate-storage.phtml
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+use Hyva\ReactCheckout\ViewModel\ReactCheckoutLocalStorage;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+/** @var Escaper $escaper */
+/** @var ReactCheckoutLocalStorage $localStorageViewModel */
+
+$localStorageViewModel = $block->getData('hyva_react_checkout_localstorage');
+?>
+<script>
+    var storageKey = 'hyva-checkout-storage';
+
+    function _toNumber(value) {
+        return parseInt(value, 10);
+    }
+
+    function initializeHyvaReactStorage() {
+        var storageConfig =
+            JSON.stringify('<?= $escaper->escapeJs($localStorageViewModel->getLocalStorageConfig()) ?>') || {};
+
+        var isLoggedIn = storageConfig.customerIsLoggedIn;
+        var storageData = {
+            customer: {
+                billing_address_id: 'cart_billing_address',
+                shipping_address_id: 'cart_shipping_address',
+            },
+            is_billing_same_as_shipping: true,
+        };
+
+        if (!isLoggedIn) {
+            window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+            return;
+        }
+
+        var quoteContainsBilling = storageConfig.quoteContainsBilling;
+        var quoteContainsShipping = storageConfig.quoteContainsShipping;
+        var quoteBillingAddressCustomerId = storageConfig.quoteBillingAddressCustomerId;
+        var quoteShippingAddressCustomerId = storageConfig.quoteShippingAddressCustomerId;
+        var defaultBillingAddressId = storageConfig.defaultBillingAddressId;
+        var defaultShippingAddressId = storageConfig.defaultShippingAddressId;
+        var billingAddressId = quoteContainsBilling ? quoteBillingAddressCustomerId : defaultBillingAddressId;
+        var shippingAddressId = quoteContainsShipping ? quoteShippingAddressCustomerId : defaultShippingAddressId;
+
+        if (!billingAddressId && !shippingAddressId) {
+            window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+            return;
+        }
+
+        storageData.customer.billing_address_id = billingAddressId;
+        storageData.customer.shipping_address_id = shippingAddressId;
+        storageData.is_billing_same_as_shipping = billingAddressId === shippingAddressId;
+        window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+    }
+
+    window.addEventListener("private-content-loaded", initializeHyvaReactStorage);
+</script>

--- a/src/view/frontend/templates/luma/initiate-storage.phtml
+++ b/src/view/frontend/templates/luma/initiate-storage.phtml
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+use Hyva\ReactCheckout\ViewModel\ReactCheckoutLocalStorage;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+/** @var Escaper $escaper */
+/** @var ReactCheckoutLocalStorage $localStorageViewModel */
+
+$localStorageViewModel = $block->getData('hyva_react_checkout_localstorage');
+?>
+<script>
+    var storageKey = 'hyva-checkout-storage';
+
+    function _toNumber(value) {
+        return parseInt(value, 10);
+    }
+
+    function initializeHyvaReactStorage() {
+        var storageConfig =
+            JSON.stringify('<?= $escaper->escapeJs($localStorageViewModel->getLocalStorageConfig()) ?>') || {};
+
+        var isLoggedIn = storageConfig.customerIsLoggedIn;
+        var storageData = {
+            customer: {
+                billing_address_id: 'cart_billing_address',
+                shipping_address_id: 'cart_shipping_address',
+            },
+            is_billing_same_as_shipping: true,
+        };
+
+        if (!isLoggedIn) {
+            window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+            return;
+        }
+
+        var quoteContainsBilling = storageConfig.quoteContainsBilling;
+        var quoteContainsShipping = storageConfig.quoteContainsShipping;
+        var quoteBillingAddressCustomerId = storageConfig.quoteBillingAddressCustomerId;
+        var quoteShippingAddressCustomerId = storageConfig.quoteShippingAddressCustomerId;
+        var defaultBillingAddressId = storageConfig.defaultBillingAddressId;
+        var defaultShippingAddressId = storageConfig.defaultShippingAddressId;
+        var billingAddressId = quoteContainsBilling ? quoteBillingAddressCustomerId : defaultBillingAddressId;
+        var shippingAddressId = quoteContainsShipping ? quoteShippingAddressCustomerId : defaultShippingAddressId;
+
+        if (!billingAddressId && !shippingAddressId) {
+            window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+            return;
+        }
+
+        storageData.customer.billing_address_id = billingAddressId;
+        storageData.customer.shipping_address_id = shippingAddressId;
+        storageData.is_billing_same_as_shipping = billingAddressId === shippingAddressId;
+        window.localStorage.setItem(storageKey, JSON.stringify(storageData));
+    }
+
+    require(['domReady!'], function() {
+        'use strict';
+        initializeHyvaReactStorage();
+    });
+</script>

--- a/src/view/frontend/templates/luma/react-script.phtml
+++ b/src/view/frontend/templates/luma/react-script.phtml
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Template $block */
+/** @var Escaper $escaper */
+
+$buildJsFile = 'Hyva_ReactCheckout::js/react-checkout.js';
+?>
+<script>
+    function loadReactCartScript () {
+        var scriptTag = 'script';
+        var firstScript = document.getElementsByTagName(scriptTag)[0];
+        var newScript = document.createElement(scriptTag);
+
+        newScript.async = true;
+        newScript.defer = true;
+        newScript.src = '<?= $escaper->escapeUrl($block->getViewFileUrl($buildJsFile)); ?>';
+
+        firstScript.parentNode.insertBefore(newScript, firstScript);
+    }
+
+    require(['domReady!'], function() {
+        'use strict';
+        loadReactCartScript();
+    });
+</script>


### PR DESCRIPTION
- local storage initialization done via different phtml file and not done via `react-script.phtml` file because, this is something we dont need to duplicate in example template module where `react-script.phtml` file does exists and it will be more difficult to manage it in the future.
- Using different phtml files in the case of luma theme as the `private-content-loaded` event is not present there and hence, I suspect this will break react checkout in the case of the luma theme.