### PR TITLE
Update translations replacer to support multiple variables

### DIFF
--- a/src/reactapp/src/i18n/__.js
+++ b/src/reactapp/src/i18n/__.js
@@ -9,8 +9,8 @@ export default function __(stringToTranslate, ...dataReplacers) {
     return stringLiteral;
   }
 
-  dataReplacers.forEach((dataToReplace) => {
-    stringLiteral = stringLiteral.replace('%1', __(dataToReplace));
+  dataReplacers.forEach((dataToReplace, index) => {
+    stringLiteral = stringLiteral.replace(`%${index + 1}`, __(dataToReplace));
   });
 
   return stringLiteral;

--- a/src/reactapp/src/utils/address.js
+++ b/src/reactapp/src/utils/address.js
@@ -51,7 +51,7 @@ export function formatAddressListToCardData(addressList, stateList) {
         prepareFullName({ firstname, lastname }),
         company,
         ...street,
-        __('%1 %1', zipcode, city),
+        __('%1 %2', zipcode, city),
         regionLabel || _get(countryRegion, 'name'),
         countryCode || country,
         __('Phone: %1', phone),


### PR DESCRIPTION
Add index in the translations replacer to support **multiple variables** in translation strings.

**Example :**
`__('Here is my first var : %1, then here is my second var : %2, etc.', myFirstVar, mySecondVar))`

