### PR TITLE
#348 Remove mage-cache-storage.cart.cartId when customer login from the checkout page.

### DIFF
--- a/src/view/frontend/templates/initiate-storage.phtml
+++ b/src/view/frontend/templates/initiate-storage.phtml
@@ -34,6 +34,14 @@ $localStorageViewModel = $block->getData('hyva_react_checkout_localstorage');
         if (!isLoggedIn) {
             window.localStorage.setItem(storageKey, JSON.stringify(storageData));
             return;
+        } else {
+            var mageCacheStorage = JSON.parse(window.localStorage.getItem('mage-cache-storage'));
+            var customerToken = mageCacheStorage.customer && mageCacheStorage.customer.signin_token;
+
+            if (!customerToken) {
+                mageCacheStorage.cart.cartId = '';
+                window.localStorage.setItem('mage-cache-storage', JSON.stringify(mageCacheStorage));
+            }
         }
 
         var quoteContainsBilling = storageConfig.quoteContainsBilling;

--- a/src/view/frontend/templates/initiate-storage.phtml
+++ b/src/view/frontend/templates/initiate-storage.phtml
@@ -34,14 +34,6 @@ $localStorageViewModel = $block->getData('hyva_react_checkout_localstorage');
         if (!isLoggedIn) {
             window.localStorage.setItem(storageKey, JSON.stringify(storageData));
             return;
-        } else {
-            var mageCacheStorage = JSON.parse(window.localStorage.getItem('mage-cache-storage'));
-            var customerToken = mageCacheStorage.customer && mageCacheStorage.customer.signin_token;
-
-            if (!customerToken) {
-                mageCacheStorage.cart.cartId = '';
-                window.localStorage.setItem('mage-cache-storage', JSON.stringify(mageCacheStorage));
-            }
         }
 
         var quoteContainsBilling = storageConfig.quoteContainsBilling;

--- a/src/view/frontend/templates/luma/initiate-storage.phtml
+++ b/src/view/frontend/templates/luma/initiate-storage.phtml
@@ -43,6 +43,7 @@ $localStorageViewModel = $block->getData('hyva_react_checkout_localstorage');
             if (!customerToken) {
                 var newCustomerToken = '<?= $escaper->escapeJs($localStorageViewModel->getCustomerToken()) ?>';
                 mageCacheStorage.customer.signin_token = newCustomerToken;
+                mageCacheStorage.cart.cartId = '';
                 window.localStorage.setItem('mage-cache-storage', JSON.stringify(mageCacheStorage));
             }
         }


### PR DESCRIPTION
We are already passing the cartId via checkoutConfig. So if the cart id is not present in the localstorage, then the cartid passed via checkoutConfig will be used. This will make sure the react checkout uses the correct cartid to load the checkout page.
